### PR TITLE
fixes for Mimic module

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/MapInfo.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/MapInfo.kt
@@ -21,7 +21,7 @@ import net.minecraft.network.protocol.game.ClientboundSystemChatPacket
 
 object MapInfo : Module(
     name = "Map Info",
-    description = "Displays stats about the dungeon such as score, secrets, and deaths."
+    description = "Displays stats about the dungeon such as score, secrets, and deaths. \nRequires \"Mimic\" enabled to be accurate"
 ) {
     private val disableInBoss by BooleanSetting("Disable in boss", true, desc = "Disables the information display when you're in boss.")
     private val scoreTitle by BooleanSetting("300 Score Title", true, desc = "Displays a title on 300 score.")

--- a/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/Mimic.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/Mimic.kt
@@ -8,7 +8,6 @@ import com.odtheking.odin.events.ChatPacketEvent
 import com.odtheking.odin.events.core.on
 import com.odtheking.odin.events.core.onReceive
 import com.odtheking.odin.features.Module
-import com.odtheking.odin.utils.sendChatMessage
 import com.odtheking.odin.utils.sendCommand
 import com.odtheking.odin.utils.skyblock.dungeon.DungeonListener
 import com.odtheking.odin.utils.skyblock.dungeon.DungeonUtils


### PR DESCRIPTION
Fixes mimic kill being registered on berserk ultimate ability's minions dying and mimic kill not being registered when the Mimic module is disabled resulting in the score in Map Info being wrong