### PR TITLE
fix: config not being created correctly if folder wasn't present

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/OdinMod.kt
+++ b/src/main/kotlin/com/odtheking/odin/OdinMod.kt
@@ -44,8 +44,9 @@ object OdinMod : ClientModInitializer {
      */
     val configFile: File = File(mc.gameDirectory, "config/odin/").apply {
         try {
-            parentFile.mkdirs()
-            createNewFile()
+            if (!exists()) {
+                mkdirs()
+            }
         } catch (e: Exception) {
             println("Error initializing module config\n${e.message}")
             logger.error("Error initializing module config", e)


### PR DESCRIPTION
Fixed oversight I missed, since I already had a folder created.