### PR TITLE
fix: performance issue with EntityRendererMixin

### DIFF
--- a/src/main/java/com/odtheking/mixin/mixins/EntityRendererMixin.java
+++ b/src/main/java/com/odtheking/mixin/mixins/EntityRendererMixin.java
@@ -14,6 +14,11 @@ public abstract class EntityRendererMixin<T extends Entity> {
 
     @Inject(method = "shouldRender", at = @At("HEAD"), cancellable = true)
     private void onRender(T entity, Frustum frustum, double d, double e, double f, CallbackInfoReturnable<Boolean> cir) {
-        cir.setReturnValue(HidePlayers.shouldRenderPlayer(entity));
+        if (!HidePlayers.shouldRenderPlayer(entity)) {
+            cir.setReturnValue(false); // only return false if shouldRenderPlayer returns false - future reference: if any more things that hide entitiess are added in future, modify the condition to be true if any of them returns false
+        }
+        // return value not overridden for other cases (see https://github.com/odtheking/OdinFabric/issues/43 - overriding the value to true can create performance regressions)
     }
+
 }
+


### PR DESCRIPTION
OP confirmed that removing the mixin from mixins.json fixes the issue. This most likely would fix the issue as well without removing the mixin, but still needs testing by OP for a final time.

Fixes #43 - see the issue for all the details about the performance issue.