### PR TITLE
fix: performance issue with EntityRendererMixin (1.21.8 backport)

### DIFF
--- a/src/main/java/com/odtheking/mixin/mixins/EntityRendererMixin.java
+++ b/src/main/java/com/odtheking/mixin/mixins/EntityRendererMixin.java
@@ -14,6 +14,11 @@ public abstract class EntityRendererMixin<T extends Entity> {
 
     @Inject(method = "shouldRender", at = @At("HEAD"), cancellable = true)
     private void onRender(T entity, Frustum frustum, double d, double e, double f, CallbackInfoReturnable<Boolean> cir) {
-        cir.setReturnValue(HidePlayers.shouldRenderPlayer(entity));
+        if (!HidePlayers.shouldRenderPlayer(entity)) {
+            cir.setReturnValue(false); // only return false if shouldRenderPlayer returns false - future reference: if any more things that hide entitiess are added in future, modify the condition to be true if any of them returns false
+        }
+        // return value not overridden for other cases (see https://github.com/odtheking/OdinFabric/issues/43 - overriding the value to true can create performance regressions)
     }
+
 }
+


### PR DESCRIPTION
The same as #44 but cherry-picked on top of the 1.21.8 branch instead.

I'll send the GitHub actions link to OP for testing to see if it actually resolves the issue once the workflows are approved to be ran.