### PR TITLE
fix: don't assume first death has Spirit Pet

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
@@ -111,7 +111,7 @@ object DungeonListener {
                 dungeonTeammates.find { teammate ->
                     teammate.name == (match.groupValues[1].takeUnless { it == "You" } ?: mc.player?.name?.string)
                 }?.let { teammate ->
-                    teammate.deaths.inc()
+                    teammate.deaths++
                     if (firstDeath == null) {
                         firstDeath = teammate
                         scope.launch {

--- a/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
@@ -12,7 +12,9 @@ import com.odtheking.odin.events.core.onReceive
 import com.odtheking.odin.features.impl.dungeon.LeapMenu
 import com.odtheking.odin.features.impl.dungeon.LeapMenu.odinSorting
 import com.odtheking.odin.features.impl.dungeon.Mimic
+import com.odtheking.odin.utils.modMessage
 import com.odtheking.odin.utils.network.WebUtils.hasBonusPaulScore
+import com.odtheking.odin.utils.network.hypixelapi.RequestUtils
 import com.odtheking.odin.utils.romanToInt
 import com.odtheking.odin.utils.skyblock.dungeon.DungeonUtils.getDungeonTeammates
 import com.odtheking.odin.utils.skyblock.dungeon.tiles.Room
@@ -37,6 +39,9 @@ object DungeonListener {
     var floor: Floor? = null
     var inBoss = false
     var paul = false
+
+    private var firstDeath: DungeonPlayer? = null
+    var firstDeathHasSpirit = false
 
     private fun getBoss(): Boolean = with(mc.player) {
         if (this == null || floor?.floorNumber == null) return false
@@ -105,7 +110,20 @@ object DungeonListener {
             deathRegex.find(value)?.let { match ->
                 dungeonTeammates.find { teammate ->
                     teammate.name == (match.groupValues[1].takeUnless { it == "You" } ?: mc.player?.name?.string)
-                }?.deaths?.inc()
+                }?.let { teammate ->
+                    teammate.deaths.inc()
+                    if (firstDeath == null) {
+                        firstDeath = teammate
+                        scope.launch {
+                            val profile = RequestUtils.getProfile(teammate.name)
+                            val memberData = profile.getOrElse { return@launch modMessage(it.message) }.memberData
+                                ?: return@launch modMessage("Could not find member data for ${teammate.name}")
+                            firstDeathHasSpirit = memberData.pets.pets.any {
+                                it.type.equals("SPIRIT", true) && it.tier == "LEGENDARY"
+                            }
+                        }
+                    }
+                }
             }
 
             when (partyMessageRegex.find(value)?.groupValues?.get(1)?.lowercase() ?: return@on) {

--- a/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonUtils.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonUtils.kt
@@ -47,6 +47,9 @@ object DungeonUtils {
     inline val deathCount: Int
         get() = DungeonListener.dungeonStats.deaths
 
+    inline val deathPenalty: Int
+        get() = ((deathCount * 2) - (if (DungeonListener.firstDeathHasSpirit) 1 else 0)).coerceAtLeast(0)
+
     inline val cryptCount: Int
         get() = DungeonListener.dungeonStats.crypts
 
@@ -130,7 +133,7 @@ object DungeonUtils {
             val skillRooms = floor(completed.toFloat() / total * 80f).coerceIn(0f, 80f).toInt()
             val puzzlePenalty = (puzzleCount - puzzles.count { it.status == PuzzleStatus.Completed }) * 10
 
-            return exploration + (20 + skillRooms - puzzlePenalty - (deathCount * 2 - 1).coerceAtLeast(0)).coerceIn(
+            return exploration + (20 + skillRooms - puzzlePenalty - deathPenalty).coerceIn(
                 20,
                 100
             ) + getBonusScore + 100
@@ -138,11 +141,9 @@ object DungeonUtils {
 
     inline val neededSecretsAmount: Int
         get() =
-            DungeonListener.floor?.let {
+            DungeonListener.floor?.let { floor ->
                 ceil(
-                    (totalSecrets * it.secretPercentage) * (40 - getBonusScore + (deathCount * 2 - 1).coerceAtLeast(
-                        0
-                    )) / 40f
+                    (totalSecrets * floor.secretPercentage) * (40 - getBonusScore + deathPenalty) / 40f
                 ).toInt()
             } ?: 0
 


### PR DESCRIPTION
Added a check to score calculation whether the player who died first has a Legendary Spirit Pet, rather than assuming they do.