### PR TITLE
textPlacement calc for L shape - dungeon map

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/map/MapRoom.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/map/MapRoom.kt
@@ -113,13 +113,15 @@ class MapRoom(val data: RoomData, val height: Int) {
         if (rotation == Rotations.NONE) return tiles.minBy { it.pos.x * 1000 + it.pos.z }.placement()
         val placements = tiles.map { it.placement() }
 
-        return when (data.shape) {
+        val x = (placements.minOf { it.x } + placements.maxOf { it.x }) / 2
+        val z = when (data.shape) {
             RoomShape.L ->
-                Vec2i(placements.sumOf { it.x } / placements.size, placements.sumOf { it.z } / placements.size)
+                if (rotation == Rotations.WEST || rotation == Rotations.NORTH) placements.minOf { it.z } else placements.maxOf { it.z }
 
             else ->
-                Vec2i((placements.minOf { it.x } + placements.maxOf { it.x }) / 2, (placements.minOf { it.z } + placements.maxOf { it.z }) / 2)
+                (placements.minOf { it.z } + placements.maxOf { it.z }) / 2
         }
+        return Vec2i(x, z)
     }
 }
 


### PR DESCRIPTION
after: 
<img width="208" height="210" alt="image" src="https://github.com/user-attachments/assets/f6ed0181-0aa9-41e2-b4d6-9b1d68f49dec" />

i think this looks way better

before: 
<img width="207" height="205" alt="image" src="https://github.com/user-attachments/assets/50eeeadd-485b-426b-9cb9-209706ca0273" />
