### PR TITLE
fix: prevent setting mimic dead on floors with no mimic

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
@@ -15,7 +15,6 @@ import com.odtheking.odin.features.impl.dungeon.Mimic
 import com.odtheking.odin.utils.network.WebUtils.hasBonusPaulScore
 import com.odtheking.odin.utils.noControlCodes
 import com.odtheking.odin.utils.romanToInt
-import com.odtheking.odin.utils.skyblock.dungeon.DungeonUtils.getDungeonTeammates
 import com.odtheking.odin.utils.skyblock.dungeon.tiles.Room
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -111,7 +110,7 @@ object DungeonListener {
 
             when (partyMessageRegex.find(value)?.groupValues?.get(1)?.lowercase() ?: return@on) {
                 "mimic killed", "mimic slain", "mimic killed!", "mimic dead", "mimic dead!", $$"$skytils-dungeon-score-mimic$", Mimic.mimicMessage ->
-                    dungeonStats.mimicKilled = true
+                    if (DungeonUtils.isFloor(6, 7)) dungeonStats.mimicKilled = true
 
                 "prince killed", "prince slain", "prince killed!", "prince dead", "prince dead!", $$"$skytils-dungeon-score-prince$", Mimic.princeMessage ->
                     dungeonStats.princeKilled = true
@@ -166,7 +165,7 @@ object DungeonListener {
     }
 
     private fun updateDungeonTeammates(tabList: List<String>) = mc.execute {
-        dungeonTeammates = getDungeonTeammates(dungeonTeammates, tabList)
+        dungeonTeammates = DungeonUtils.getDungeonTeammates(dungeonTeammates, tabList)
         dungeonTeammatesNoSelf = dungeonTeammates.filter { it.name != mc.player?.name?.string }
 
         leapTeammates =
@@ -205,10 +204,19 @@ object DungeonListener {
         var deaths: Int = 0,
         var percentCleared: Int = 0,
         var elapsedTime: String = "0s",
-        var mimicKilled: Boolean = false,
+        private var _mimicKilled: Boolean = false,
         var princeKilled: Boolean = false,
         var doorOpener: String = "Unknown",
         var bloodDone: Boolean = false,
         var puzzleCount: Int = 0,
-    )
+    ) {
+        var mimicKilled: Boolean
+            get() = _mimicKilled
+            set(value) {
+                if (value && !DungeonUtils.isFloor(6, 7)) {
+                    error("Attempted to set mimicKilled = true on floor that has no mimic")
+                }
+                _mimicKilled = value
+            }
+    }
 }


### PR DESCRIPTION
Someone got mimic bonus score assumed on M5 on somehow, though they didn't see a message from a party member so I'm not sure if it was this, but I added a sanity check anyway.