### PR TITLE
ci: upload artifact without zipping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           path: |
             build/libs/Odin-*.jar
-            !build/libs/Odin*-sources.jar
+            !build/libs/Odin-*-sources.jar
           archive: false
 
       - name: upload sources jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,16 @@ jobs:
       - name: build
         run: ./gradlew build
 
-      - name: capture build artifacts
-        uses: actions/upload-artifact@v4
+      - name: upload release jar
+        uses: actions/upload-artifact@v7.0.0
         with:
-          name: Artifacts
-          path: build/libs/
+          path: |
+            build/libs/Odin-*.jar
+            !build/libs/Odin*-sources.jar
+          archive: false
+
+      - name: upload sources jar
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          path: build/libs/Odin-*-sources.jar
+          archive: false


### PR DESCRIPTION
Changes the workflow to upload build artifacts without an additional layer of zipping, per <https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/>.