### PR TITLE
PUZZLE HUD!

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/features/ModuleManager.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/ModuleManager.kt
@@ -61,7 +61,7 @@ object ModuleManager {
             PuzzleSolvers, BlessingDisplay, LeapMenu, SecretClicked, MapInfo, Mimic, DungeonQueue,
             KeyHighlight, BloodCamp, PositionalMessages, TerracottaTimer, BreakerDisplay, LividSolver,
             InvincibilityTimer, SpiritBear, DungeonWaypoints, ExtraStats, BetterPartyFinder, Croesus, MageBeam, DungeonMap,
-            SecretsCounter,
+            SecretsCounter, PuzzleHud,
 
             // floor 7
             TerminalSimulator, TerminalSolver, TerminalTimes, TerminalSounds, TickTimers, ArrowAlign,

--- a/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/PuzzleHud.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/PuzzleHud.kt
@@ -3,8 +3,7 @@ package com.odtheking.odin.features.impl.dungeon
 import com.odtheking.odin.clickgui.settings.impl.BooleanSetting
 import com.odtheking.odin.features.Module
 import com.odtheking.odin.utils.Colors
-import com.odtheking.odin.utils.render.getStringWidth
-import com.odtheking.odin.utils.render.text
+import com.odtheking.odin.utils.render.textDim
 import com.odtheking.odin.utils.skyblock.dungeon.DungeonUtils
 import com.odtheking.odin.utils.skyblock.dungeon.Puzzle
 import com.odtheking.odin.utils.skyblock.dungeon.PuzzleStatus
@@ -15,22 +14,22 @@ object PuzzleHud : Module(
 ) {
     private val showPlayerNames by BooleanSetting("Show Player Names", true, desc = "Shows which player solved or failed the puzzle.")
 
+    private data class PuzzleEntry(val name: String, val statusIcon: String, val statusColor: String, val player: String?)
+    private val examplePuzzles = listOf(
+        PuzzleEntry(Puzzle.ICE_PATH.displayName, "✖", "§c", "odtheking"),
+        PuzzleEntry(Puzzle.BEAMS.displayName, "✔", "§a", null),
+        PuzzleEntry(Puzzle.UNKNOWN.displayName, "✦", "§6", null),
+        PuzzleEntry(Puzzle.UNKNOWN.displayName, "✦", "§6", null)
+    )
+
     private val hud by HUD("Puzzle HUD Position", "Displays dungeon puzzle statuses on the HUD.") { example ->
         if (!DungeonUtils.inDungeons && !example) return@HUD 0 to 0
 
         val puzzleCount = if (example) 4 else DungeonUtils.puzzleCount
-        if (puzzleCount == 0 && !example) return@HUD 0 to 0
+        if (puzzleCount == 0) return@HUD 0 to 0
 
-        data class PuzzleEntry(val name: String, val statusIcon: String, val statusColor: String, val player: String?)
-
-        val entries: List<PuzzleEntry> = if (example) {
-            listOf(
-                PuzzleEntry(Puzzle.BLAZE.displayName, "✖", "§c", "ItsAkar1881"),
-                PuzzleEntry(Puzzle.BEAMS.displayName, "✔", "§a", "Player123"),
-                PuzzleEntry(Puzzle.UNKNOWN.displayName, "✦", "§6", null),
-                PuzzleEntry(Puzzle.UNKNOWN.displayName, "✦", "§6", null)
-            )
-        } else {
+        val entries = if (example) examplePuzzles
+        else {
             val discovered = DungeonUtils.puzzles.map { puzzle ->
                 val (icon, color) = when (puzzle.status) {
                     PuzzleStatus.Completed -> "✔" to "§a"
@@ -41,25 +40,20 @@ object PuzzleHud : Module(
                 PuzzleEntry(puzzle.displayName, icon, color, puzzle.player)
             }
             val undiscoveredCount = (puzzleCount - discovered.size).coerceAtLeast(0)
-            val undiscovered = (1..undiscoveredCount).map {
-                PuzzleEntry("???", "✦", "§6", null)
-            }
+            val undiscovered = (1..undiscoveredCount).map { PuzzleEntry("???", "✦", "§6", null) }
             discovered + undiscovered
         }
 
         var width = 0
         val lineHeight = 12
 
-        val headerText = "§fPuzzles: (§3$puzzleCount§f)"
-        text(headerText, 0, 0, Colors.WHITE)
-        getStringWidth("Puzzles: ($puzzleCount)").let { if (it > width) width = it }
+        val headerText = "§5Puzzles §8(§3$puzzleCount§8)"
+        width = textDim(headerText, 0, 0, Colors.WHITE).first
 
         entries.forEachIndexed { index, entry ->
-            val y = (index + 1) * lineHeight
             val playerText = if (showPlayerNames && entry.player != null) " §7(${entry.player})" else ""
-            val line = "§f${entry.name}: [${entry.statusColor}${entry.statusIcon}§f]$playerText"
-            text(line, 0, y, Colors.WHITE)
-            getStringWidth("${entry.name}: [${entry.statusIcon}]${if (showPlayerNames && entry.player != null) " (${entry.player})" else ""}").let { if (it > width) width = it }
+            val newWidth = textDim("§e${entry.name}§8: [${entry.statusColor}${entry.statusIcon}§8]$playerText", 0, (index + 1) * lineHeight, Colors.WHITE).first
+            if (newWidth > width) width = newWidth
         }
 
         val totalLines = entries.size + 1

--- a/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/PuzzleHud.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/dungeon/PuzzleHud.kt
@@ -1,0 +1,68 @@
+package com.odtheking.odin.features.impl.dungeon
+
+import com.odtheking.odin.clickgui.settings.impl.BooleanSetting
+import com.odtheking.odin.features.Module
+import com.odtheking.odin.utils.Colors
+import com.odtheking.odin.utils.render.getStringWidth
+import com.odtheking.odin.utils.render.text
+import com.odtheking.odin.utils.skyblock.dungeon.DungeonUtils
+import com.odtheking.odin.utils.skyblock.dungeon.Puzzle
+import com.odtheking.odin.utils.skyblock.dungeon.PuzzleStatus
+
+object PuzzleHud : Module(
+    name = "Puzzle HUD",
+    description = "Displays remaining, completed, and failed puzzles in the HUD during dungeons."
+) {
+    private val showPlayerNames by BooleanSetting("Show Player Names", true, desc = "Shows which player solved or failed the puzzle.")
+
+    private val hud by HUD("Puzzle HUD Position", "Displays dungeon puzzle statuses on the HUD.") { example ->
+        if (!DungeonUtils.inDungeons && !example) return@HUD 0 to 0
+
+        val puzzleCount = if (example) 4 else DungeonUtils.puzzleCount
+        if (puzzleCount == 0 && !example) return@HUD 0 to 0
+
+        data class PuzzleEntry(val name: String, val statusIcon: String, val statusColor: String, val player: String?)
+
+        val entries: List<PuzzleEntry> = if (example) {
+            listOf(
+                PuzzleEntry(Puzzle.BLAZE.displayName, "✖", "§c", "ItsAkar1881"),
+                PuzzleEntry(Puzzle.BEAMS.displayName, "✔", "§a", "Player123"),
+                PuzzleEntry(Puzzle.UNKNOWN.displayName, "✦", "§6", null),
+                PuzzleEntry(Puzzle.UNKNOWN.displayName, "✦", "§6", null)
+            )
+        } else {
+            val discovered = DungeonUtils.puzzles.map { puzzle ->
+                val (icon, color) = when (puzzle.status) {
+                    PuzzleStatus.Completed -> "✔" to "§a"
+                    PuzzleStatus.Failed -> "✖" to "§c"
+                    PuzzleStatus.Incomplete -> "✦" to "§6"
+                    null -> "✦" to "§6"
+                }
+                PuzzleEntry(puzzle.displayName, icon, color, puzzle.player)
+            }
+            val undiscoveredCount = (puzzleCount - discovered.size).coerceAtLeast(0)
+            val undiscovered = (1..undiscoveredCount).map {
+                PuzzleEntry("???", "✦", "§6", null)
+            }
+            discovered + undiscovered
+        }
+
+        var width = 0
+        val lineHeight = 12
+
+        val headerText = "§fPuzzles: (§3$puzzleCount§f)"
+        text(headerText, 0, 0, Colors.WHITE)
+        getStringWidth("Puzzles: ($puzzleCount)").let { if (it > width) width = it }
+
+        entries.forEachIndexed { index, entry ->
+            val y = (index + 1) * lineHeight
+            val playerText = if (showPlayerNames && entry.player != null) " §7(${entry.player})" else ""
+            val line = "§f${entry.name}: [${entry.statusColor}${entry.statusIcon}§f]$playerText"
+            text(line, 0, y, Colors.WHITE)
+            getStringWidth("${entry.name}: [${entry.statusIcon}]${if (showPlayerNames && entry.player != null) " (${entry.player})" else ""}").let { if (it > width) width = it }
+        }
+
+        val totalLines = entries.size + 1
+        width to totalLines * lineHeight
+    }
+}

--- a/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonEnums.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonEnums.kt
@@ -47,7 +47,8 @@ data class DungeonPlayer(
  */
 enum class Puzzle(
     val displayName: String,
-    var status: PuzzleStatus? = null
+    var status: PuzzleStatus? = null,
+    var player: String? = null
 ) {
     UNKNOWN("???"),
     BLAZE("Higher Or Lower"),

--- a/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
@@ -136,7 +136,8 @@ object DungeonListener {
 
     private fun getDungeonPuzzles(tabList: List<String>) {
         for (entry in tabList) {
-            val (name, status) = puzzleRegex.find(entry)?.destructured ?: continue
+            val match = puzzleRegex.find(entry) ?: continue
+            val (name, status, player) = match.destructured
             val puzzle = Puzzle.entries.find { it.displayName == name }?.takeIf { it != Puzzle.UNKNOWN } ?: continue
             if (puzzle !in puzzles) puzzles.add(puzzle)
 
@@ -146,6 +147,7 @@ object DungeonListener {
                 "✦" -> PuzzleStatus.Incomplete
                 else -> continue
             }
+            if (player.isNotEmpty()) puzzle.player = player
         }
     }
 

--- a/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonListener.kt
@@ -136,18 +136,17 @@ object DungeonListener {
 
     private fun getDungeonPuzzles(tabList: List<String>) {
         for (entry in tabList) {
-            val match = puzzleRegex.find(entry) ?: continue
-            val (name, status, player) = match.destructured
+            val (name, status, player) = puzzleRegex.find(entry)?.destructured ?: continue
             val puzzle = Puzzle.entries.find { it.displayName == name }?.takeIf { it != Puzzle.UNKNOWN } ?: continue
             if (puzzle !in puzzles) puzzles.add(puzzle)
 
+            if (player.isNotEmpty()) puzzle.player = player
             puzzle.status = when (status) {
                 "✖" -> PuzzleStatus.Failed
                 "✔" -> PuzzleStatus.Completed
                 "✦" -> PuzzleStatus.Incomplete
                 else -> continue
             }
-            if (player.isNotEmpty()) puzzle.player = player
         }
     }
 


### PR DESCRIPTION
added NEW PUZZLE HUD for dungeons. i made this bc a couple people wanted it and suggested it in dc server. i think its useful tho bc sometimes people forget to check the tablist, so if its right on the screen u wont miss it.

features:
- shows all puzzles and status: ✔ (done), ✖ (fail), ✦ (in progress)
- if u didnt find it yet it says ??? (gets total count from tab)
- header shows total puzzles like Puzzles: (5)
- option to SHOW PLAYER NAMES to see who solved or failed
- colors r exactly same as tab list (white, aqua, green, etc)
- u can move it around in HUD EDITOR

here is a pic how it looks
<img width="529" height="361" alt="Screenshot_2026-04-15-18-55-34-116_com movtery zalithlauncher-edit" src="https://github.com/user-attachments/assets/4f46a07f-e6eb-405b-a1d4-4de9c02db152" />
