### PR TITLE
build: fix runClient with non-JBR Java

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,8 @@ loom {
                 "-Dmixin.debug.export=true",
                 "-Ddevauth.enabled=true",
                 "-Ddevauth.account=main",
-                "-XX:+AllowEnhancedClassRedefinition"
+                "-XX:+AllowEnhancedClassRedefinition",
+                "-XX:+IgnoreUnrecognizedVMOptions", // AllowEnhancedClassRedefinition is only available on JBR
             )
         )
     }


### PR DESCRIPTION
Fixes the `runClient` Gradle task failing if you aren't using the JetBrains JBR runtime, which is required for `-XX:+AllowEnhancedClassRedefinition` to work.