### PR TITLE
Feat/fancyGUI

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/OdinMod.kt
+++ b/src/main/kotlin/com/odtheking/odin/OdinMod.kt
@@ -16,6 +16,7 @@ import com.odtheking.odin.utils.skyblock.*
 import com.odtheking.odin.utils.skyblock.dungeon.DungeonListener
 import com.odtheking.odin.utils.skyblock.dungeon.DungeonUtils
 import com.odtheking.odin.utils.skyblock.dungeon.ScanUtils
+import com.odtheking.odin.features.impl.boss.termGUI.FancyTermGui
 import com.odtheking.odin.utils.skyblock.dungeon.terminals.TerminalUtils
 import com.odtheking.odin.utils.ui.rendering.NVGPIPRenderer
 import com.odtheking.odin.utils.ui.widget.CustomGUIImpl
@@ -75,7 +76,7 @@ object OdinMod : ClientModInitializer {
             DungeonListener, PartyUtils, TerminalUtils,
             ScanUtils, DungeonUtils, SplitsManager,
             IrisCompatability, RenderBatchManager,
-            ModuleManager, CustomGUIImpl, Shenanigans
+            ModuleManager, CustomGUIImpl, Shenanigans, FancyTermGui
         ).forEach { EventBus.subscribe(it) }
 
         SpecialGuiElementRegistry.register { context ->

--- a/src/main/kotlin/com/odtheking/odin/features/impl/boss/TerminalSolver.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/boss/TerminalSolver.kt
@@ -7,6 +7,7 @@ import com.odtheking.odin.events.GuiEvent
 import com.odtheking.odin.events.TerminalEvent
 import com.odtheking.odin.events.core.on
 import com.odtheking.odin.features.Module
+import com.odtheking.odin.utils.Color
 import com.odtheking.odin.utils.Color.Companion.darker
 import com.odtheking.odin.utils.Colors
 import com.odtheking.odin.utils.skyblock.dungeon.terminals.TerminalTypes
@@ -19,18 +20,21 @@ object TerminalSolver : Module(
     name = "Terminal Solver",
     description = "Renders solution for terminals in floor 7."
 ) {
-    private val renderType by SelectorSetting("Render type", "Odin", arrayListOf("Odin", "Normal", "Custom GUI"), desc = "How the terminal solver should render.")
+    private val renderType by SelectorSetting("Render type", "Odin", arrayListOf("Odin", "Normal", "Custom GUI", "Fancy GUI"), desc = "How the terminal solver should render.")
     private val normalTermSize by NumberSetting("Normal Term Size", 3, 1, 5, 1, desc = "The GUI scale increase for normal terminal GUI.").withDependency { renderType == 0 || renderType == 1 }
     val customTermSize by NumberSetting("Term Size", 2f, 1f, 3f, 0.1f, desc = "The size of the custom terminal GUI.").withDependency { renderType == 2 }
     val roundness by NumberSetting("Roundness", 5, 0f, 15f, 1f, desc = "The roundness of the custom terminal gui.").withDependency { renderType == 2 }
     val gap by NumberSetting("Slot gap", 2, 0, 8, 1, desc = "The gap between the slots in the custom terminal gui.").withDependency { renderType == 2 }
+
+    val fancyScale by NumberSetting("Scale", 2f, 1f, 5f, 0.1f, desc = "The scale of the Fancy GUI (1-5).").withDependency { renderType == 3 }
+    val fancyGuiBorderRadius by NumberSetting("GUI Border Radius", 5, 0f, 10f, 1f, desc = "Corner roundness of the Fancy GUI panel (0 = no roundness, max 10).").withDependency { renderType == 3 }
+    val fancyButtonBorderRadius by NumberSetting("Button Border Radius", 3, 0f, 10f, 1f, desc = "Corner roundness of the Fancy GUI buttons (0 = no roundness, max 10).").withDependency { renderType == 3 }
 
     private val solverSettings by DropdownSetting("Solver Functionality")
     private val cancelToolTip by BooleanSetting("Stop Tooltips", true, desc = "Stops rendering tooltips in terminals.").withDependency { (renderType == 0 || renderType == 1) && solverSettings }
     private val middleClickGUI by BooleanSetting("Middle Click GUI", true, desc = "Replaces right click with middle click in terminals.").withDependency { (renderType == 0 || renderType == 1) && solverSettings }
     private val blockIncorrectClicks by BooleanSetting("Block Incorrect Clicks", true, desc = "Blocks incorrect clicks in terminals.").withDependency { (renderType == 0 || renderType == 1) && solverSettings }
     private val cancelMelodySolver by BooleanSetting("Stop Melody Solver", false, desc = "Stops rendering the melody solver.").withDependency { solverSettings }
-    val melodyTermSize by NumberSetting("Melody Size", 1.5f, 1f, 3f, 0.1f, desc = "The size of the melody terminal GUI.").withDependency { !cancelMelodySolver && solverSettings }
     val showNumbers by BooleanSetting("Show Numbers", true, desc = "Shows numbers in the order terminal.").withDependency { solverSettings }
     val firstClickProt by NumberSetting("First Click Protection", 500, 350, 800, 10, unit = "ms", desc = "The amount of time after opening a terminal where clicks are blocked to prevent bans (recommended value is 500 minus your ping).").withDependency { solverSettings }
     val hideClicked by BooleanSetting("Hide Clicked", false, desc = "Visually hides your first click before a gui updates instantly to improve perceived response time. Does not affect actual click time.").withDependency { solverSettings }
@@ -61,6 +65,7 @@ object TerminalSolver : Module(
 
     @JvmStatic val termSize get() = if (enabled && (renderType == 0 || renderType == 1) && TerminalUtils.currentTerm != null) normalTermSize else 1
     val customGuiEnabled get() = enabled && renderType == 2 && renderMelody
+    val fancyGuiEnabled get() = enabled && renderType == 3 && renderMelody
     private val renderMelody get() = !(cancelMelodySolver && TerminalUtils.currentTerm?.type == TerminalTypes.MELODY)
 
     init {

--- a/src/main/kotlin/com/odtheking/odin/features/impl/boss/TerminalSolver.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/boss/TerminalSolver.kt
@@ -25,7 +25,6 @@ object TerminalSolver : Module(
     val customTermSize by NumberSetting("Term Size", 2f, 1f, 3f, 0.1f, desc = "The size of the custom terminal GUI.").withDependency { renderType == 2 }
     val roundness by NumberSetting("Roundness", 5, 0f, 15f, 1f, desc = "The roundness of the custom terminal gui.").withDependency { renderType == 2 }
     val gap by NumberSetting("Slot gap", 2, 0, 8, 1, desc = "The gap between the slots in the custom terminal gui.").withDependency { renderType == 2 }
-
     val fancyScale by NumberSetting("Scale", 2f, 1f, 5f, 0.1f, desc = "The scale of the Fancy GUI (1-5).").withDependency { renderType == 3 }
     val fancyGuiBorderRadius by NumberSetting("GUI Border Radius", 5, 0f, 10f, 1f, desc = "Corner roundness of the Fancy GUI panel (0 = no roundness, max 10).").withDependency { renderType == 3 }
     val fancyButtonBorderRadius by NumberSetting("Button Border Radius", 3, 0f, 10f, 1f, desc = "Corner roundness of the Fancy GUI buttons (0 = no roundness, max 10).").withDependency { renderType == 3 }
@@ -35,6 +34,8 @@ object TerminalSolver : Module(
     private val middleClickGUI by BooleanSetting("Middle Click GUI", true, desc = "Replaces right click with middle click in terminals.").withDependency { (renderType == 0 || renderType == 1) && solverSettings }
     private val blockIncorrectClicks by BooleanSetting("Block Incorrect Clicks", true, desc = "Blocks incorrect clicks in terminals.").withDependency { (renderType == 0 || renderType == 1) && solverSettings }
     private val cancelMelodySolver by BooleanSetting("Stop Melody Solver", false, desc = "Stops rendering the melody solver.").withDependency { solverSettings }
+    val melodyTermSize by NumberSetting("Melody Size", 1.5f, 1f, 3f, 0.1f, desc = "The size of the melody terminal GUI.").withDependency { !cancelMelodySolver && solverSettings }
+    val fancyGuiEnabled get() = enabled && renderType == 3 && renderMelody
     val showNumbers by BooleanSetting("Show Numbers", true, desc = "Shows numbers in the order terminal.").withDependency { solverSettings }
     val firstClickProt by NumberSetting("First Click Protection", 500, 350, 800, 10, unit = "ms", desc = "The amount of time after opening a terminal where clicks are blocked to prevent bans (recommended value is 500 minus your ping).").withDependency { solverSettings }
     val hideClicked by BooleanSetting("Hide Clicked", false, desc = "Visually hides your first click before a gui updates instantly to improve perceived response time. Does not affect actual click time.").withDependency { solverSettings }
@@ -65,7 +66,6 @@ object TerminalSolver : Module(
 
     @JvmStatic val termSize get() = if (enabled && (renderType == 0 || renderType == 1) && TerminalUtils.currentTerm != null) normalTermSize else 1
     val customGuiEnabled get() = enabled && renderType == 2 && renderMelody
-    val fancyGuiEnabled get() = enabled && renderType == 3 && renderMelody
     private val renderMelody get() = !(cancelMelodySolver && TerminalUtils.currentTerm?.type == TerminalTypes.MELODY)
 
     init {

--- a/src/main/kotlin/com/odtheking/odin/features/impl/boss/termGUI/FancyTermGui.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/boss/termGUI/FancyTermGui.kt
@@ -1,0 +1,215 @@
+package com.odtheking.odin.features.impl.boss.termGUI
+
+import com.odtheking.odin.OdinMod.mc
+import com.odtheking.odin.events.GuiEvent
+import com.odtheking.odin.events.ScreenEvent
+import com.odtheking.odin.events.core.on
+import com.odtheking.odin.features.impl.boss.TerminalSolver
+import com.odtheking.odin.utils.Color
+import com.odtheking.odin.utils.Color.Companion.brighter
+import com.odtheking.odin.utils.Colors
+import com.odtheking.odin.utils.render.roundedFill
+import com.odtheking.odin.utils.render.text
+import com.odtheking.odin.utils.skyblock.dungeon.terminals.TerminalTypes
+import com.odtheking.odin.utils.skyblock.dungeon.terminals.TerminalUtils
+import com.odtheking.odin.utils.ui.widget.CustomGUIImpl
+import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import org.lwjgl.glfw.GLFW
+
+object FancyTermGui {
+
+    private const val SLOT_SIZE = 24f
+    private const val SLOT_GAP = 2f
+    private const val PADDING = 12
+
+    private data class SlotBox(
+        val slotIndex: Int,
+        val bx: Float,
+        val by: Float,
+        val size: Float,
+        val getVisual: () -> Pair<Color, String?>?
+    ) {
+        fun contains(x: Float, y: Float) = x >= bx && y >= by && x < bx + size && y < by + size
+    }
+
+    private data class Grid(
+        val originX: Float,
+        val originY: Float,
+        val w: Float,
+        val h: Float,
+        val slots: List<SlotBox>
+    ) {
+        fun toBase(screenX: Double, screenY: Double, scale: Float) =
+            Pair((screenX.toFloat() - originX) / scale, (screenY.toFloat() - originY) / scale)
+    }
+
+    private var currentGrid: Grid? = null
+    private var hoveredSlotIndex: Int? = null
+
+    @JvmStatic
+    fun isActive(): Boolean {
+        return TerminalSolver.fancyGuiEnabled &&
+                TerminalUtils.currentTerm != null &&
+                mc.screen is AbstractContainerScreen<*>
+    }
+
+    private data class GridLayout(val rows: Int, val cols: Int, val startRow: Int, val startCol: Int)
+
+    private fun getGridLayout(type: TerminalTypes): GridLayout = when (type) {
+        TerminalTypes.PANES -> GridLayout(3, 5, 1, 2)
+        TerminalTypes.RUBIX -> GridLayout(3, 3, 1, 3)
+        TerminalTypes.NUMBERS -> GridLayout(2, 7, 1, 1)
+        TerminalTypes.STARTS_WITH -> GridLayout(3, 7, 1, 1)
+        TerminalTypes.SELECT -> GridLayout(4, 7, 1, 1)
+        TerminalTypes.MELODY -> GridLayout(5, 7, 0, 1)
+    }
+
+    private fun buildGrid(screen: AbstractContainerScreen<*>) {
+        val term = TerminalUtils.currentTerm ?: return
+        val type = term.type
+        val scale = TerminalSolver.fancyScale
+        val layout = getGridLayout(type)
+
+        val (rows, cols, startRow, startCol) = layout
+        val w = cols * SLOT_SIZE + (cols - 1) * SLOT_GAP
+        val h = rows * SLOT_SIZE + (rows - 1) * SLOT_GAP
+
+        val slots = buildList {
+            for (row in 0 until rows) {
+                for (col in 0 until cols) {
+                    val index = (startRow + row) * 9 + (startCol + col)
+                    val r = index / 9
+                    val c = index % 9
+
+                    val getVisual: () -> Pair<Color, String?>? = when (type) {
+                        TerminalTypes.MELODY -> ({
+                            val solution = TerminalUtils.currentTerm?.solution
+                            val inSolution = solution?.contains(index) == true
+                            val color: Color? = when {
+                                r == 0 -> if (inSolution) TerminalSolver.melodyColumColor else null
+                                c == 7 -> if (inSolution) TerminalSolver.melodyPointerColor else TerminalSolver.melodyBackgroundColor
+                                c in 1..5 -> if (inSolution) TerminalSolver.melodyPointerColor else TerminalSolver.melodyBackgroundColor
+                                else -> null
+                            }
+                            color?.let { it to null }
+                        })
+                        else -> ({ TerminalUtils.currentTerm?.getSlotRendering(index) })
+                    }
+
+                    if (type == TerminalTypes.MELODY) {
+                        if (r == 0 || (c == 7 && r in 1..4) || c in 1..5) {
+                            add(SlotBox(index, col * (SLOT_SIZE + SLOT_GAP), row * (SLOT_SIZE + SLOT_GAP), SLOT_SIZE, getVisual))
+                        }
+                    } else {
+                        add(SlotBox(index, col * (SLOT_SIZE + SLOT_GAP), row * (SLOT_SIZE + SLOT_GAP), SLOT_SIZE, getVisual))
+                    }
+                }
+            }
+        }
+
+        currentGrid = Grid(
+            originX = (screen.width - w * scale) / 2f,
+            originY = (screen.height - h * scale) / 2f,
+            w = w, h = h,
+            slots = slots
+        )
+    }
+
+    @JvmStatic
+    fun handleClick(mouseX: Double, mouseY: Double, button: Int): Boolean {
+        if (!isActive()) return false
+        val g = currentGrid ?: return true
+        val scale = TerminalSolver.fancyScale
+        val (bx, by) = g.toBase(mouseX, mouseY, scale)
+
+        val slot = g.slots.firstOrNull { it.contains(bx, by) } ?: return true
+
+        val term = TerminalUtils.currentTerm ?: return true
+        val screen = mc.screen ?: return true
+        val btn = if (button == 0) GLFW.GLFW_MOUSE_BUTTON_3 else button
+
+        if (System.currentTimeMillis() - term.timeOpened >= TerminalSolver.firstClickProt &&
+            !GuiEvent.CustomTermGuiClick(screen, slot.slotIndex, btn).postAndCatch() &&
+            term.canClick(slot.slotIndex, btn)
+        ) {
+            term.click(slot.slotIndex, btn, TerminalSolver.hideClicked && !term.isClicked)
+        }
+        return true
+    }
+
+    init {
+        on<GuiEvent.SlotClick> {
+            if (isActive()) cancel()
+        }
+
+        CustomGUIImpl.register(CustomGUIImpl.HandlerSet(
+            enabled = ::isActive,
+            render = fun ScreenEvent.Render.(): Any {
+                val screen = mc.screen as? AbstractContainerScreen<*> ?: return false
+                buildGrid(screen)
+                renderFancy(guiGraphics, mouseX, mouseY)
+                return true
+            },
+            click = fun ScreenEvent.MouseClick.(): Any {
+                handleClick(click.x(), click.y(), click.button())
+                return true
+            }
+        ))
+    }
+
+    private fun renderFancy(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int) {
+        val g = currentGrid ?: return
+        val scale = TerminalSolver.fancyScale
+        val guiBgColor = TerminalSolver.backgroundColor
+        val guiRadius = TerminalSolver.fancyGuiBorderRadius
+        val btnRadius = TerminalSolver.fancyButtonBorderRadius
+
+        val (baseMX, baseMY) = g.toBase(mouseX.toDouble(), mouseY.toDouble(), scale)
+        hoveredSlotIndex = null
+
+        guiGraphics.pose().pushMatrix()
+        guiGraphics.pose().translate(g.originX, g.originY)
+        guiGraphics.pose().scale(scale)
+
+        val accentColor = guiBgColor.brighter(1.8f)
+        guiGraphics.roundedFill(
+            -PADDING, -PADDING,
+            g.w.toInt() + PADDING, g.h.toInt() + PADDING,
+            guiBgColor.rgba, guiRadius,
+            accentColor.rgba, 1.5f
+        )
+
+        g.slots.forEach { slot ->
+            val (color, text) = slot.getVisual() ?: return@forEach
+            val isHovered = slot.contains(baseMX, baseMY)
+            if (isHovered) hoveredSlotIndex = slot.slotIndex
+
+            val displayColor = if (isHovered) color.brighter(1.3f) else color
+            val bx = slot.bx.toInt()
+            val by = slot.by.toInt()
+            val sz = slot.size.toInt()
+
+            guiGraphics.roundedFill(bx, by, bx + sz, by + sz, displayColor.rgba, btnRadius)
+
+            val highlightAlpha = (displayColor.alphaFloat * 0.25f).coerceIn(0f, 1f)
+            val highlightColor = Color(
+                minOf(255, displayColor.red + 50),
+                minOf(255, displayColor.green + 50),
+                minOf(255, displayColor.blue + 50),
+                highlightAlpha
+            )
+            if (sz > 4) {
+                guiGraphics.roundedFill(bx + 1, by + 1, bx + sz - 1, by + sz / 3, highlightColor.rgba, btnRadius)
+            }
+
+            text?.let {
+                val tx = bx + (sz - mc.font.width(it)) / 2
+                val ty = by + (sz - mc.font.lineHeight) / 2 + 1
+                guiGraphics.text(it, tx, ty, Colors.WHITE)
+            }
+        }
+
+        guiGraphics.pose().popMatrix()
+    }
+}


### PR DESCRIPTION
Adds a Fancy GUI mode to the Terminal Solver and fixes a couple of long-standing click bugs along the way.

So the main thing here is a new render mode for terminals, sitting next to the existing Normal and Custom modes. I called it Fancy GUI (renderType 3). It's basically a cleaner, rounder, scalable take on the terminal layout. Each terminal type (Order, Starts With, Select, and the Rubix/Panes one) gets its own grid built straight from the screen's live slots, so it always reflects the real state. Rounded panel, rounded buttons, hover highlights, slot labels - all the stuff you'd expect. Scales from 1x to 5x without going blurry because it all goes through roundedFill and the matrix stack does the scaling.

The whole thing lives in a new file, FancyTermGui.kt under features/impl/boss/termGUI/. It's a standalone object that registers itself as a CustomGUIImpl handler set, so it plugs into the same pipeline Custom GUI already uses - no new mixins, no new event types, nothing exotic.

For settings, there are three new ones under Terminal Solver, all only visible when Render Type is set to Fancy GUI: Scale (1.0 to 5.0, default 2.0), GUI Border Radius (0-10, default 5), and Button Border Radius (0-10, default 3). They show up inline right under Render Type, the same way Custom shows Term Size, Roundness and Slot gap, and the same way Normal shows Normal Term Size. No extra dropdown wrapper. The panel background colour deliberately is NOT a separate setting - it just reuses the existing "Background" swatch under Color Settings, so all three modes share the same background colour and there's nothing duplicated.


Verification: gradlew build runs clean, BUILD SUCCESSFUL, no warnings. Existing Normal, Custom and Odin modes are completely untouched. Fancy GUI tested across all four terminal types - clicks land on the right slot, no double packets, no voids, REI search bar still works when REI is loaded, and the background colour responds to the shared Background swatch as expected.

Should be fine but i will keep it as a draft.

https://github.com/user-attachments/assets/8bfee87b-9f0f-431d-b2dd-a0dc4dc4f141

