### PR TITLE
fix: Fixed the tick timer issue

### DIFF
--- a/src/main/java/com/odtheking/mixin/mixins/ConnectionMixin.java
+++ b/src/main/java/com/odtheking/mixin/mixins/ConnectionMixin.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelHandlerContext;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.common.ClientboundPingPacket;
+import net.minecraft.network.protocol.ping.ClientboundPongResponsePacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -17,7 +18,8 @@ public abstract class ConnectionMixin {
 
     @Inject(method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/protocol/Packet;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/Connection;genericsFtw(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;)V"), cancellable = true)
     private void channelRead0(ChannelHandlerContext channelHandlerContext, Packet<?> packet, CallbackInfo ci) {
-        if (packet instanceof ClientboundPingPacket pingPacket && pingPacket.getId() != 0) TickEvent.Server.INSTANCE.postAndCatch();
+        // Hypixel server-tick packet (old: ClientboundPingPacket, new: ClientboundPongResponsePacket).
+        if ((packet instanceof ClientboundPingPacket pingPacket && pingPacket.getId() != 0) || packet instanceof ClientboundPongResponsePacket) TickEvent.Server.INSTANCE.postAndCatch();
         if (new PacketEvent.Receive(packet).postAndCatch()) ci.cancel();
     }
 


### PR DESCRIPTION
`ClientboundPingPacket` Is no longer a valid packet, `ClientboundPongResponsePacket` now is what we get per server tick 
`ConnectionMixin` Now uses the new one
      ```java
      if ((packet instanceof ClientboundPingPacket pingPacket && pingPacket.getId() != 0) || packet instanceof ClientboundPongResponsePacket) TickEvent.Server.INSTANCE.postAndCatch();
      ```