### PR TITLE
Swapped Archer and Berserk colors

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonEnums.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/skyblock/dungeon/DungeonEnums.kt
@@ -84,8 +84,8 @@ enum class DungeonClass(
     val defaultQuadrant: Int,
     var priority: Int,
 ) {
-    ARCHER(Colors.MINECRAFT_GOLD, '6', 0, 2),
-    BERSERK(Colors.MINECRAFT_DARK_RED, '4', 1, 0),
+    ARCHER(Colors.MINECRAFT_DARK_RED, '4', 0, 2),
+    BERSERK(Colors.MINECRAFT_GOLD, '6', 1, 0),
     HEALER(Colors.MINECRAFT_LIGHT_PURPLE, 'd', 2, 2),
     MAGE(Colors.MINECRAFT_AQUA, 'b', 3, 2),
     TANK(Colors.MINECRAFT_DARK_GREEN, '2', 3, 1),


### PR DESCRIPTION
Simply swaps the colors for the Archer and Berserker.

Most dungeon mods use the following class color convention: Healer (Purple), Archer (Red), Berserker (Orange), Tank (Green), and Mage (Aqua).

When using features such as the Leap Menu and Extra Stats alongside dungeon features from other mods, the inconsistent class colors can be confusing.

### Leap Menu after this change:

<div align="center">
<img width="761" height="376" alt="image" src="https://github.com/user-attachments/assets/26a75de4-ffe0-413a-84c0-dac3f685a46f" />

</div>
