### PR TITLE
Detailed TPS statistics

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/commands/MainCommand.kt
+++ b/src/main/kotlin/com/odtheking/odin/commands/MainCommand.kt
@@ -24,7 +24,8 @@ val mainCommand = Commodore("odin", "od") {
     }
 
     literal("tps").runs {
-        modMessage("§aTPS: §f${ServerUtils.averageTps}")
+        val stats = ServerUtils.getLast20TpsStatistics()
+        modMessage("§aCurrent: §f${ServerUtils.averageTps.toFixed(1)}§a, Last 20 pings: (max/min/avg) §f${stats.max.toFixed(1)}/${stats.min.toFixed(1)}/${stats.average.toFixed(1)}")
     }
 
     literal("ping").runs {

--- a/src/main/kotlin/com/odtheking/odin/commands/MainCommand.kt
+++ b/src/main/kotlin/com/odtheking/odin/commands/MainCommand.kt
@@ -24,8 +24,7 @@ val mainCommand = Commodore("odin", "od") {
     }
 
     literal("tps").runs {
-        val stats = ServerUtils.getLast20TpsStatistics()
-        modMessage("§aCurrent: §f${ServerUtils.averageTps.toFixed(1)}§a, Last 20 pings: (max/min/avg) §f${stats.max.toFixed(1)}/${stats.min.toFixed(1)}/${stats.average.toFixed(1)}")
+        modMessage(ServerUtils.getTpsString())
     }
 
     literal("ping").runs {

--- a/src/main/kotlin/com/odtheking/odin/features/impl/skyblock/ChatCommands.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/skyblock/ChatCommands.kt
@@ -43,6 +43,7 @@ object ChatCommands : Module(
     private val reinvite by BooleanSetting("Reinvite", false, desc = "Reinvites the player who sent it a few seconds later.").withDependency { showSettings }
     private val ping by BooleanSetting("Ping", true, desc = "Sends your current Ping.").withDependency { showSettings }
     private val tps by BooleanSetting("Tps", true, desc = "Sends your server's current TPS.").withDependency { showSettings }
+    private val detailedTps by BooleanSetting("Detailed TPS", false, desc = "Includes maximum, minimum, and average TPS from the last 20 samples.").withDependency { showSettings && tps }
     private val fps by BooleanSetting("FPS", true, desc = "Sends your current FPS.").withDependency { showSettings }
     private val dt by BooleanSetting("DT", true, desc = "Sets a reminder for the end of the run.").withDependency { showSettings }
     private val invite by BooleanSetting("Invite", true, desc = "Invites the player to your party.").withDependency { showSettings }
@@ -135,7 +136,14 @@ object ChatCommands : Module(
             "dice" -> if (dice) channelMessage((1..6).random(), name, channel)
             "racism" -> if (racism) channelMessage("$name is ${Random.nextInt(1, 101)}% racist. Racism is not allowed!", name, channel)
             "ping" -> if (ping) channelMessage("Current Ping: ${ServerUtils.currentPing}ms", name, channel)
-            "tps" -> if (tps) channelMessage("Current TPS: ${ServerUtils.averageTps.toFixed(1)}", name, channel)
+            "tps" -> if (tps) channelMessage(
+                if (detailedTps) {
+                    val stats = ServerUtils.getLast20TpsStatistics()
+                    "Current: ${ServerUtils.averageTps.toFixed(1)}, Last 20 pings: (max/min/avg) ${stats.max.toFixed(1)}/${stats.min.toFixed(1)}/${stats.average.toFixed(1)}"
+                } else "Current TPS: ${ServerUtils.averageTps.toFixed(1)}",
+                name,
+                channel
+            )
             "fps" -> if (fps) channelMessage("Current FPS: ${mc.fps}", name, channel)
             "time" -> if (time) channelMessage("Current Time: ${ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z"))}", name, channel)
             "location" -> if (location) channelMessage("Current Location: ${LocationUtils.currentArea.displayName}", name, channel)

--- a/src/main/kotlin/com/odtheking/odin/features/impl/skyblock/ChatCommands.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/skyblock/ChatCommands.kt
@@ -43,7 +43,6 @@ object ChatCommands : Module(
     private val reinvite by BooleanSetting("Reinvite", false, desc = "Reinvites the player who sent it a few seconds later.").withDependency { showSettings }
     private val ping by BooleanSetting("Ping", true, desc = "Sends your current Ping.").withDependency { showSettings }
     private val tps by BooleanSetting("Tps", true, desc = "Sends your server's current TPS.").withDependency { showSettings }
-    private val detailedTps by BooleanSetting("Detailed TPS", false, desc = "Includes maximum, minimum, and average TPS from the last 20 samples.").withDependency { showSettings && tps }
     private val fps by BooleanSetting("FPS", true, desc = "Sends your current FPS.").withDependency { showSettings }
     private val dt by BooleanSetting("DT", true, desc = "Sets a reminder for the end of the run.").withDependency { showSettings }
     private val invite by BooleanSetting("Invite", true, desc = "Invites the player to your party.").withDependency { showSettings }
@@ -136,14 +135,7 @@ object ChatCommands : Module(
             "dice" -> if (dice) channelMessage((1..6).random(), name, channel)
             "racism" -> if (racism) channelMessage("$name is ${Random.nextInt(1, 101)}% racist. Racism is not allowed!", name, channel)
             "ping" -> if (ping) channelMessage("Current Ping: ${ServerUtils.currentPing}ms", name, channel)
-            "tps" -> if (tps) channelMessage(
-                if (detailedTps) {
-                    val stats = ServerUtils.getLast20TpsStatistics()
-                    "Current: ${ServerUtils.averageTps.toFixed(1)}, Last 20 pings: (max/min/avg) ${stats.max.toFixed(1)}/${stats.min.toFixed(1)}/${stats.average.toFixed(1)}"
-                } else "Current TPS: ${ServerUtils.averageTps.toFixed(1)}",
-                name,
-                channel
-            )
+            "tps" -> if (tps) channelMessage(ServerUtils.getTpsString(), name, channel)
             "fps" -> if (fps) channelMessage("Current FPS: ${mc.fps}", name, channel)
             "time" -> if (time) channelMessage("Current Time: ${ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z"))}", name, channel)
             "location" -> if (location) channelMessage("Current Location: ${LocationUtils.currentArea.displayName}", name, channel)

--- a/src/main/kotlin/com/odtheking/odin/utils/ServerUtils.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/ServerUtils.kt
@@ -5,10 +5,14 @@ import com.odtheking.odin.events.core.onReceive
 import net.minecraft.network.protocol.game.ClientboundSetTimePacket
 import net.minecraft.network.protocol.ping.ClientboundPongResponsePacket
 import net.minecraft.util.Util
+import java.util.ArrayDeque
 import kotlin.math.min
 
 object ServerUtils {
+    data class TpsStatistics(val max: Float, val min: Float, val average: Float)
+
     private var prevTime = 0L
+    private val tpsLog = ArrayDeque<Float>(20)
     var averageTps = 20f
         private set
 
@@ -18,10 +22,19 @@ object ServerUtils {
     var averagePing: Int = 0
         private set
 
+    fun getLast20TpsStatistics(): TpsStatistics {
+        if (tpsLog.isEmpty()) return TpsStatistics(averageTps, averageTps, averageTps)
+
+        return TpsStatistics(tpsLog.max(), tpsLog.min(), tpsLog.average().toFloat())
+    }
+
     init {
         onReceive<ClientboundSetTimePacket> {
-            if (prevTime != 0L)
+            if (prevTime != 0L) {
                 averageTps = (20000f / (System.currentTimeMillis() - prevTime + 1)).coerceIn(0f, 20f)
+                if (tpsLog.size == 20) tpsLog.removeFirst()
+                tpsLog.addLast(averageTps)
+            }
 
             prevTime = System.currentTimeMillis()
         }

--- a/src/main/kotlin/com/odtheking/odin/utils/ServerUtils.kt
+++ b/src/main/kotlin/com/odtheking/odin/utils/ServerUtils.kt
@@ -9,10 +9,7 @@ import java.util.ArrayDeque
 import kotlin.math.min
 
 object ServerUtils {
-    data class TpsStatistics(val max: Float, val min: Float, val average: Float)
-
     private var prevTime = 0L
-    private val tpsLog = ArrayDeque<Float>(20)
     var averageTps = 20f
         private set
 
@@ -22,18 +19,29 @@ object ServerUtils {
     var averagePing: Int = 0
         private set
 
-    fun getLast20TpsStatistics(): TpsStatistics {
-        if (tpsLog.isEmpty()) return TpsStatistics(averageTps, averageTps, averageTps)
+    private const val TPS_HISTORY = 20
 
-        return TpsStatistics(tpsLog.max(), tpsLog.min(), tpsLog.average().toFloat())
+    private val tpsLog = FloatArray(TPS_HISTORY)
+    private var tpsIndex = 0
+    private var tpsCount = 0
+
+    private fun addTpsSample(tps: Float) {
+        tpsLog[tpsIndex] = tps
+        tpsIndex = (tpsIndex + 1) % TPS_HISTORY
+        if (tpsCount < TPS_HISTORY) tpsCount++
+    }
+
+    fun getTpsString(): String {
+        if (tpsLog.isEmpty()) return "Current: ${averageTps.toFixed(1)}"
+
+        return "Current: ${averageTps.toFixed(1)} (max/min/avg) ${tpsLog.max().toFixed(1)}/${tpsLog.min().toFixed(1)}/${tpsLog.average().toFloat().toFixed(1)}"
     }
 
     init {
         onReceive<ClientboundSetTimePacket> {
             if (prevTime != 0L) {
                 averageTps = (20000f / (System.currentTimeMillis() - prevTime + 1)).coerceIn(0f, 20f)
-                if (tpsLog.size == 20) tpsLog.removeFirst()
-                tpsLog.addLast(averageTps)
+                addTpsSample(averageTps)
             }
 
             prevTime = System.currentTimeMillis()


### PR DESCRIPTION
It is common for a server to experience a short lag spike. However, running the `!tps` or `/odin tps` command a second later may already show 20.0 TPS again, making the spike difficult to detect.

This update makes Odin store the last 20 TPS readings and calculate the minimum, maximum, and average TPS values from those samples:

<img width="686" height="43" alt="TPS statistics showing minimum, maximum, and average values" src="https://github.com/user-attachments/assets/4ab8f4e5-10ce-44fd-97b9-6800af5f8e71" />

This feature can be enabled or disabled in the settings:

<img width="739" height="102" alt="Setting for enabling TPS statistics" src="https://github.com/user-attachments/assets/0bb6d198-80c7-44c6-a565-d39293f4357a" />
